### PR TITLE
Initial draft of document metadata

### DIFF
--- a/power-curve-schema/examples/generic-117-3.json
+++ b/power-curve-schema/examples/generic-117-3.json
@@ -1,6 +1,20 @@
 {
-  "label": "generic-117-3",
-  "document_version": "GENERIC0001",
+  "document": {
+    "metadata": [
+      {
+        "term": "Identifier",
+        "value": "my-uuid"
+      },
+      {
+        "term": "Format",
+        "value": "IEC61400-16-1"
+      },
+      {
+        "term": "Source",
+        "value": "Doc 12345 - Rev 01"
+      }
+    ]
+  },
   "turbine_metadata": {
     "model_name": "GT 3.45-117",
     "model_description": "A generic turbine based on supergeneric(TM) technology and featuring the GeneriX blade system.",

--- a/power-curve-schema/examples/generic-274-20.json
+++ b/power-curve-schema/examples/generic-274-20.json
@@ -1,6 +1,20 @@
 {
-  "label": "generic-274-20",
-  "document_version": "GENERIC0002",
+  "document": {
+    "metadata": [
+      {
+        "term": "Identifier",
+        "value": "my-uuid-2"
+      },
+      {
+        "term": "Format",
+        "value": "IEC61400-16-1"
+      },
+      {
+        "term": "Source",
+        "value": "Doc 56789 - Rev 01"
+      }
+    ]
+  },
   "turbine_metadata": {
     "model_name": "GT 20.0-274",
     "model_description": "A generic turbine based on supergeneric(TM) technology and featuring the InfinityXYZ Generiblade system.",

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "title": "Turbine Power Curve",
-  "description": "Define a wind turbine power curve.",
+  "title": "Turbine Power Curves",
+  "description": "Define a set of power curves for a wind turbine.",
   "definitions": {
     "1darray": {
       "type": "array",
@@ -58,31 +58,57 @@
     }
   },
   "required": [
-    "document_version",
+    "document",
     "turbine_metadata",
-    "design_parameters",
+    "design_basis",
     "default_mode",
     "modes"
   ],
   "properties": {
-    "label": {
-      "type": "string",
-      "title": "Power curve label",
-      "description": "An optional slugified string key used to reference this power curve, eg siemens-swt-whatever. This is best used as an identifier within a database or graph (in the same way that mode labels are used to reference a given mode within the power curve - see the 'modes' property)",
-      "pattern": "^([a-z][a-z0-9]*)(-[a-z0-9]+)*$",
-      "message": {
-        "pattern": "Correct format of the label is kebab-case (lowercase, numeric digits and hyphens only)"
-      },
-      "examples": ["example-simple"]
-    },
-    "document_version": {
-      "type": "string",
-      "title": "Document version",
-      "description": "Manufacturer's document reference (from which raw power curves data is taken)",
-      "message": {
-        "required": "Document version is a required property"
-      },
-      "examples": ["Vestas Document no. 0067-7067 V09, 2018-09-25"]
+    "document": {
+      "type": "object",
+      "title": "Document",
+      "description": "Information about this document",
+      "required": ["metadata"],
+      "properties": {
+        "metadata": {
+          "title": "Dublin-Core Metadata",
+          "description": "Add metadata according to the Dublin Core Metadata Initiative (DCMI) elements/1.1. See https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#section-3 for detailed information on each element.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["term", "value"],
+            "properties": {
+              "term": {
+                "type": "string",
+                "title": "Term",
+                "description": "The DCMI Element label",
+                "enum": [
+                  "Contributor",
+                  "Coverage",
+                  "Creator",
+                  "Date",
+                  "Description",
+                  "Format",
+                  "Identifier",
+                  "Language",
+                  "Publisher",
+                  "Relation",
+                  "Rights",
+                  "Source",
+                  "Subject",
+                  "Type"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "The metadata value"
+              }
+            }
+          }
+        }
+      }
     },
     "turbine_metadata": {
       "type": "object",


### PR DESCRIPTION
# Summary

I've added DCMI terms in a list format just now (quitevanilla). This is subject to change, we may use object form and may constrain some terms to not be listed values (eg to have single entries for identifier, type, etc).

<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#38](https://github.com/octue/power-curve-schema/pull/38))

**IMPORTANT:** There is 1 breaking change.

### Enhancements
- 💥 **BREAKING CHANGE:** Initial draft of document metadata

---
# Upgrade instructions
<details>
<summary>💥 <b>Initial draft of document metadata</b></summary>

Removed deprecated label, design_parameters and document_version and replaced with required document.metadata field. Migrate documents to account for new metadata format.
</details>

<!--- END AUTOGENERATED NOTES --->