### PR TITLE
Remove outdated attributes

### DIFF
--- a/power-curve-schema/examples/generic-117-3.json
+++ b/power-curve-schema/examples/generic-117-3.json
@@ -32,7 +32,7 @@
     "drive_type": "geared",
     "regulation_type": "pitch",
     "grid_frequencies": [50, 60],
-    "thermal_shutdown": {
+    "thermal_regulation": {
       "derating": [
         {
           "$comment": "Linear ramp down in low temperatures, altitude 2500",

--- a/power-curve-schema/examples/generic-117-3.json
+++ b/power-curve-schema/examples/generic-117-3.json
@@ -35,37 +35,37 @@
     "thermal_regulation": {
       "derating": [
         {
-          "$comment": "Linear ramp down in low temperatures, altitude 2500",
+          "legend": "Linear ramp down in low temperatures, altitude 2500",
           "altitude": 2500,
           "temperature": [-15, 10],
           "power_limit": [1.1e6, 2e6]
         },
         {
-          "$comment": "Linear ramp down in low temperatures, altitude 1250",
+          "legend": "Linear ramp down in low temperatures, altitude 1250",
           "altitude": 1250,
           "temperature": [-15, 10],
           "power_limit": [1.4e6, 2e6]
         },
         {
-          "$comment": "Linear ramp down in low temperatures, altitude 0",
+          "legend": "Linear ramp down in low temperatures, altitude 0",
           "altitude": 0,
           "temperature": [-15, 10],
           "power_limit": [1.6e6, 2e6]
         },
         {
-          "$comment": "Linear ramp down to zero in high temperatures, altitude 2500",
+          "legend": "Linear ramp down to zero in high temperatures, altitude 2500",
           "altitude": 2500,
           "temperature": [40, 45],
           "power_limit": [2e6, 0]
         },
         {
-          "$comment": "Linear ramp down to zero in high temperatures, altitude 1250",
+          "legend": "Linear ramp down to zero in high temperatures, altitude 1250",
           "altitude": 1250,
           "temperature": [42, 45],
           "power_limit": [2e6, 0]
         },
         {
-          "$comment": "Linear ramp down to zero in high temperatures, altitude 0",
+          "legend": "Linear ramp down to zero in high temperatures, altitude 0",
           "altitude": 0,
           "temperature": [42, 45],
           "power_limit": [2e6, 0]

--- a/power-curve-schema/examples/generic-117-3.json
+++ b/power-curve-schema/examples/generic-117-3.json
@@ -195,7 +195,6 @@
         "name": "Standard",
         "description": "Standard full power mode",
         "design_bases": ["basis_1", "basis_2", "basis_3"],
-        "rated_power": 3450000,
         "cuts": [
           {
             "kind": "low_cut_in",

--- a/power-curve-schema/examples/generic-274-20.json
+++ b/power-curve-schema/examples/generic-274-20.json
@@ -32,7 +32,7 @@
     "drive_type": "geared",
     "regulation_type": "pitch",
     "grid_frequencies": [50, 60],
-    "thermal_shutdown": {
+    "thermal_regulation": {
       "derating": [
         {
           "$comment": "Linear ramp down in low temperatures, air density 1.3",

--- a/power-curve-schema/examples/generic-274-20.json
+++ b/power-curve-schema/examples/generic-274-20.json
@@ -35,37 +35,37 @@
     "thermal_regulation": {
       "derating": [
         {
-          "$comment": "Linear ramp down in low temperatures, air density 1.3",
+          "legend": "Linear ramp down in low temperatures, air density 1.3",
           "air_density": 1.3,
           "temperature": [-15, 10],
           "power_limit": [1.1e6, 2e6]
         },
         {
-          "$comment": "Linear ramp down in low temperatures, air density 1.225",
+          "legend": "Linear ramp down in low temperatures, air density 1.225",
           "air_density": 1.225,
           "temperature": [-15, 10],
           "power_limit": [1.4e6, 2e6]
         },
         {
-          "$comment": "Linear ramp down in low temperatures, air density 0.9",
+          "legend": "Linear ramp down in low temperatures, air density 0.9",
           "air_density": 1.225,
           "temperature": [-15, 10],
           "power_limit": [1.6e6, 2e6]
         },
         {
-          "$comment": "Nonlinear reduction in high temperatures, air density 1.3",
+          "legend": "Nonlinear reduction in high temperatures, air density 1.3",
           "air_density": 1.3,
           "temperature": [40, 41, 42, 43, 44, 45],
           "power_limit": [2e6, 1.95e6, 1.85e6, 1.7e6, 1.4e6, 0.8e6]
         },
         {
-          "$comment": "Nonlinear reduction in high temperatures, air density 1.225",
+          "legend": "Nonlinear reduction in high temperatures, air density 1.225",
           "air_density": 1.225,
           "temperature": [40, 41, 42, 43, 44, 45],
           "power_limit": [2e6, 1.98e6, 1.89e6, 1.8e6, 1.5e6, 0.9e6]
         },
         {
-          "$comment": "Nonlinear reduction in high temperatures, air density 0.9",
+          "legend": "Nonlinear reduction in high temperatures, air density 0.9",
           "air_density": 0.9,
           "temperature": [40, 41, 42, 43, 44, 45],
           "power_limit": [2e6, 1.98e6, 1.88e6, 2.0e6, 1.7e6, 1.1e6]
@@ -121,7 +121,6 @@
         "name": "Mode 1",
         "description": "Standard full power mode",
         "design_bases": ["basis_1"],
-        "rated_power": 20000000,
         "cuts": [
           {
             "kind": "low_cut_in",
@@ -363,7 +362,6 @@
         "name": "Mode 2 (Derated low-noise)",
         "description": "Applicable for sites where noise signature is priority",
         "design_bases": ["basis_1"],
-        "rated_power": 20000000,
         "cuts": [
           {
             "kind": "low_cut_in",
@@ -597,7 +595,6 @@
         "name": "Mode 3 (High tower)",
         "description": "A mode demonstrating exclusion of certain hub heights (eg for structural reasons)",
         "design_bases": ["basis_1"],
-        "rated_power": 20000000,
         "cuts": [
           {
             "kind": "low_cut_in",

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -375,7 +375,7 @@
       "uniqueItems": true
     }
   },
-  "required": ["document", "turbine", "design_bases", "power_curves"],
+  "required": ["document", "turbine", "power_curves"],
   "properties": {
     "document": {
       "type": "object",
@@ -1049,7 +1049,6 @@
               "label",
               "name",
               "description",
-              "design_bases",
               "cuts",
               "parameters",
               "power_is_coefficient",
@@ -1076,7 +1075,7 @@
               },
               "design_bases": {
                 "type": "array",
-                "description": "A list of the design basis labels relevant to this power curve",
+                "description": "A list of the design basis labels relevant to this mode. The 'design_bases' array is not required, so this field is also not required. However, if the 'design_bases' array is provided, this field should be populated in order to determine the applicable base(s).",
                 "items": {
                   "type": "string"
                 },

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -78,6 +78,7 @@
           "title": "Specify a range of available hub heights [m]",
           "type": "object",
           "description": "Specify a range of available hub heights [m]",
+          "additionalProperties": false,
           "properties": {
             "min": {
               "type": "number",
@@ -122,11 +123,13 @@
       "title": "Thermal Regulation",
       "description": "Define thermal shutdowns and derating characteristics",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "cold": {
           "title": "Low Temperature Thermal Shutdown",
           "description": "Define low-temperature thermal shutdown characteristics",
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "shutdown_temperature": {
               "title": "Shutdown Temperature",
@@ -153,6 +156,7 @@
           "title": "High Temperature Thermal Shutdown",
           "description": "Define high-temperature thermal shutdown characteristics",
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "shutdown_temperature": {
               "title": "Shutdown Temperature",
@@ -186,6 +190,7 @@
               {
                 "title": "Altitude based derating",
                 "required": ["altitude", "power_limit", "temperature"],
+                "additionalProperties": false,
                 "properties": {
                   "altitude": {
                     "description": "The altitude at which this derating curve applies [m above the WGS84 spheroid]",
@@ -210,6 +215,7 @@
               {
                 "title": "Air density based derating",
                 "required": ["air_density", "power_limit", "temperature"],
+                "additionalProperties": false,
                 "properties": {
                   "air_density": {
                     "description": "The air density at which this derating curve applies [kg/m^3]",
@@ -376,6 +382,7 @@
     }
   },
   "required": ["document", "turbine", "power_curves"],
+  "additionalProperties": false,
   "properties": {
     "document": {
       "type": "object",
@@ -383,6 +390,7 @@
       "description": "Information about this document",
       "required": ["metadata"],
       "$comment": "We've added metadata into a property of `document` to facilitate addition of more prescriptive or specific (ie non dublin-core) properties in the future",
+      "additionalProperties": false,
       "properties": {
         "metadata": {
           "title": "Dublin-Core Metadata",
@@ -391,6 +399,7 @@
           "items": {
             "type": "object",
             "required": ["term", "value"],
+            "additionalProperties": false,
             "properties": {
               "term": {
                 "type": "string",
@@ -441,6 +450,7 @@
         "grid_frequencies",
         "thermal_regulation"
       ],
+      "additionalProperties": false,
       "properties": {
         "manufacturer_name": {
           "type": "string",
@@ -554,6 +564,7 @@
           "turbulence",
           "standard_climate"
         ],
+        "additionalProperties": false,
         "properties": {
           "label": {
             "type": "string",
@@ -589,6 +600,7 @@
                 "standard_edition": "2"
               }
             ],
+            "additionalProperties": false,
             "properties": {
               "standard": {
                 "$comment": "The use of anyOf allows specification of any string value, whilst adding an enum to indicate the precise values to be selected should your value be in the prescribed list of common items.",
@@ -637,6 +649,7 @@
                 "title": "Standard IEC design class",
                 "type": "object",
                 "required": ["class_label"],
+                "additionalProperties": false,
                 "properties": {
                   "class_label": {
                     "description": "Specify a predefined IEC design class (I, II, or III)",
@@ -656,6 +669,7 @@
                 "title": "Special or custom design class",
                 "type": "object",
                 "required": ["class_label"],
+                "additionalProperties": false,
                 "properties": {
                   "class_label": {
                     "title": "Label",
@@ -727,6 +741,7 @@
                 "type": "object",
                 "$comment": "This is defined as a single-property object rather than a direct string because it's more explicit to include the category keyword (and allows for later adoption of other predefined profiles requiring more sophistication than a string)",
                 "required": ["category"],
+                "additionalProperties": false,
                 "properties": {
                   "category": {
                     "title": "Category",
@@ -740,6 +755,7 @@
                 "type": "object",
                 "description": "Specify reference turbulence intensity",
                 "required": ["category", "reference_turbulence_intensity"],
+                "additionalProperties": false,
                 "properties": {
                   "category": {
                     "title": "Category",
@@ -761,6 +777,7 @@
                 "type": "object",
                 "description": "Specify characteristic turbulence intensity and slope consistent with IEC61400-1 Ed2",
                 "required": ["category", "characteristic_turbulence_intensity"],
+                "additionalProperties": false,
                 "properties": {
                   "category": {
                     "title": "Category",
@@ -795,6 +812,7 @@
                   "wind_speed",
                   "normal_turbulence_intensity"
                 ],
+                "additionalProperties": false,
                 "properties": {
                   "category": {
                     "title": "Category",
@@ -845,6 +863,7 @@
                   "normal_hours_per_lifetime",
                   "extreme_turbulence_intensity"
                 ],
+                "additionalProperties": false,
                 "properties": {
                   "category": {
                     "description": "Set the turbulence category to custom",
@@ -936,6 +955,7 @@
           "standard_climate": {
             "type": "object",
             "description": "Define operating and survival temperatures in standard climates",
+            "additionalProperties": false,
             "properties": {
               "operating_temperature_range": {
                 "type": "array",
@@ -964,6 +984,7 @@
           "cold_climate": {
             "type": "object",
             "description": "As per standard climate in eventuality turbine is equipped with a cold weather package",
+            "additionalProperties": false,
             "properties": {
               "operating_temperature_range": {
                 "type": "array",
@@ -993,6 +1014,7 @@
             "type": "object",
             "description": "As per standard climate in eventuality turbine is equipped with a hot weather package",
             "$comment": "TODO Schema team - Can we define why this is different in hot climates than it is in standard climates?",
+            "additionalProperties": false,
             "properties": {
               "operating_temperature_range": {
                 "type": "array",
@@ -1026,6 +1048,7 @@
       "title": "Power Curves",
       "description": "Contains power and thrust curves along with data specific to each operating mode of the turbine",
       "required": ["default_operating_mode", "operating_modes"],
+      "additionalProperties": false,
       "properties": {
         "default_operating_mode": {
           "type": "string",
@@ -1054,6 +1077,7 @@
               "thrust",
               "overrides"
             ],
+            "additionalProperties": false,
             "properties": {
               "label": {
                 "type": "string",
@@ -1095,6 +1119,7 @@
                 "items": {
                   "type": "object",
                   "required": ["kind", "wind_speed", "period"],
+                  "additionalProperties": false,
                   "properties": {
                     "kind": {
                       "title": "Cut in characteristic",
@@ -1129,6 +1154,7 @@
                 "items": {
                   "type": "object",
                   "required": ["label", "dimension", "values"],
+                  "additionalProperties": false,
                   "properties": {
                     "label": {
                       "type": "string",
@@ -1148,6 +1174,13 @@
                       "type": "integer",
                       "title": "Dimension",
                       "description": "Dimension of the power curve array along which this parameter varies (0-based)"
+                    },
+                    "values": {
+                      "type": "array",
+                      "additionalItems": true,
+                      "items": {
+                        "type": "number"
+                      }
                     }
                   },
                   "allOf": [
@@ -1162,11 +1195,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Air Density Values",
                             "description": "Values of air density [kg/m^3] for which this power curve is tabulated"
                           }
@@ -1185,11 +1213,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Wind Speed Values",
                             "description": "Values of free-stream wind speed [m/s] at hub height for which this power curve is tabulated"
                           }
@@ -1208,8 +1231,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
                             "items": {
                               "type": "number",
                               "minimum": 0,
@@ -1233,11 +1254,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Turbulence Lengthscale Values",
                             "description": "Values of turbulence integral lengthscale l [m] for which this power curve is tabulated"
                           }
@@ -1256,11 +1272,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Monin-Obukhov Stability Values",
                             "description": "Values of the the Monin-Obukhov stability parameter zeta [-] for which this power curve is tabulated. Values of zero indicate neutral conditions, vegative condi"
                           }
@@ -1279,11 +1290,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Shear Coefficient Values",
                             "description": "Values of wind shear coefficient alpha [-] for which this power curve is tabulated"
                           }
@@ -1302,11 +1308,6 @@
                       "then": {
                         "properties": {
                           "values": {
-                            "type": "array",
-                            "additionalItems": true,
-                            "items": {
-                              "type": "number"
-                            },
                             "title": "Wind Direction Values",
                             "description": "Values of wind direction [???? degrees clockwise from true north????] for which this power curve is tabulated"
                           }
@@ -1446,6 +1447,7 @@
                 "oneOf": [
                   {
                     "title": "Emissions at one-third-octave intervals",
+                    "additionalProperties": false,
                     "properties": {
                       "margin": {
                         "$ref": "#/$defs/acoustic_emissions_margin"
@@ -1488,6 +1490,7 @@
                   },
                   {
                     "title": "Emissions at full-octave intervals",
+                    "additionalProperties": false,
                     "properties": {
                       "margin": {
                         "$ref": "#/$defs/acoustic_emissions_margin"
@@ -1529,6 +1532,7 @@
                   },
                   {
                     "title": "Total emissions",
+                    "additionalProperties": false,
                     "properties": {
                       "margin": {
                         "$ref": "#/$defs/acoustic_emissions_margin"
@@ -1573,6 +1577,7 @@
                     "rated_rpm": 11.8
                   }
                 ],
+                "additionalProperties": false,
                 "properties": {
                   "rated_power": {
                     "$ref": "#/$defs/rated_power"
@@ -1596,6 +1601,7 @@
     "additional": {
       "title": "Additional",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "reference": {
           "type":"string",
@@ -1613,9 +1619,7 @@
           "description": "Add extra (e.g. manufacturer-specific) data to this field.",
           "additionalProperties": true
         }
-      },
-      "additionalProperties": false
+      }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -192,6 +192,12 @@
                 "required": ["altitude", "power_limit", "temperature"],
                 "additionalProperties": false,
                 "properties": {
+                  "legend": {
+                    "title": "Legend",
+                    "description": "A note related to the applicability or extra context describing the derating",
+                    "type": "string",
+                    "maxItems": 40
+                  },
                   "altitude": {
                     "description": "The altitude at which this derating curve applies [m above the WGS84 spheroid]",
                     "type": "number"

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -433,8 +433,6 @@
         "manufacturer_name",
         "manufacturer_display_name",
         "rated_power",
-        "rated_rpm",
-        "cut_in_rpm",
         "rotor_diameter",
         "model_description",
         "available_hub_heights",

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -738,6 +738,12 @@
               }
             ]
           },
+          "design_lifetime": {
+            "title": "Design Lifetime",
+            "description": "The design lifetime of the turbine [years]",
+            "type": "number",
+            "examples": [25, 30]
+          },
           "turbulence": {
             "title": "Turbulence category or distribution",
             "description": "Specify the IEC turbulence category or one of several custom distributions.",

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -1619,7 +1619,7 @@
     "additional": {
       "title": "Additional",
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "reference": {
           "type":"string",

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -1592,7 +1592,30 @@
           }
         }
       }
+    },
+    "additional": {
+      "title": "Additional",
+      "type": "object",
+      "properties": {
+        "reference": {
+          "type":"string",
+          "title": "Reference",
+          "description": "An optional url reference to documentation describing contents of the additional.data property."
+        },
+        "schema": {
+          "type":"string",
+          "title": "Schema",
+          "description": "An optional url reference to a schema describing contents of additional.data property."
+        },
+        "data": {
+          "title": "Additional",
+          "type": "object",
+          "description": "Add extra (e.g. manufacturer-specific) data to this field.",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -196,7 +196,7 @@
                     "title": "Legend",
                     "description": "A note related to the applicability or extra context describing the derating",
                     "type": "string",
-                    "maxItems": 40
+                    "maxItems": 80
                   },
                   "altitude": {
                     "description": "The altitude at which this derating curve applies [m above the WGS84 spheroid]",
@@ -223,6 +223,12 @@
                 "required": ["air_density", "power_limit", "temperature"],
                 "additionalProperties": false,
                 "properties": {
+                  "legend": {
+                    "title": "Legend",
+                    "description": "A note related to the applicability or extra context describing the derating",
+                    "type": "string",
+                    "maxItems": 80
+                  },
                   "air_density": {
                     "description": "The air density at which this derating curve applies [kg/m^3]",
                     "type": "number"

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -10,10 +10,8 @@
         "type": "array",
         "items": {
           "type": "number"
-        },
-        "additionalItems": true
-      },
-      "additionalItems": true
+        }
+      }
     },
     "3darray": {
       "type": "array",
@@ -23,12 +21,9 @@
           "type": "array",
           "items": {
             "type": "number"
-          },
-          "additionalItems": true
-        },
-        "additionalItems": true
-      },
-      "additionalItems": true
+          }
+        }
+      }
     },
     "4darray": {
       "type": "array",
@@ -40,14 +35,10 @@
             "type": "array",
             "items": {
               "type": "number"
-            },
-            "additionalItems": true
-          },
-          "additionalItems": true
-        },
-        "additionalItems": true
-      },
-      "additionalItems": true
+            }
+          }
+        }
+      }
     },
     "rated_power": {
       "type": "number",
@@ -379,8 +370,7 @@
         "type": "number",
         "minimum": 0
       },
-      "minItems": 1,
-      "additionalItems": true
+      "minItems": 1
     },
     "acoustic_emissions_frequency": {
       "title": "Frequency",
@@ -1080,7 +1070,6 @@
           "type": "array",
           "title": "Operating Modes",
           "description": "Different modes that the turbine can operate in / switch between",
-          "additionalItems": true,
           "items": {
             "type": "object",
             "required": [
@@ -1168,7 +1157,6 @@
                 "type": "array",
                 "title": "Parameters",
                 "description": "Independent parameters for which the power and thrust curves are described",
-                "additionalItems": true,
                 "items": {
                   "type": "object",
                   "required": ["label", "dimension", "values"],
@@ -1195,7 +1183,6 @@
                     },
                     "values": {
                       "type": "array",
-                      "additionalItems": true,
                       "items": {
                         "type": "number"
                       }

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -118,9 +118,9 @@
       },
       "examples": [[50], [50, 60]]
     },
-    "thermal_shutdown": {
-      "title": "Thermal Shutdown and Deratings",
-      "description": "Define thermal shutdown characteristic",
+    "thermal_regulation": {
+      "title": "Thermal Regulation",
+      "description": "Define thermal shutdowns and derating characteristics",
       "type": "object",
       "properties": {
         "cold": {
@@ -442,7 +442,7 @@
         "drive_type",
         "regulation_type",
         "grid_frequencies",
-        "thermal_shutdown"
+        "thermal_regulation"
       ],
       "properties": {
         "manufacturer_name": {
@@ -527,8 +527,8 @@
         "rated_power": {
           "$ref": "#/$defs/rated_power"
         },
-        "thermal_shutdown": {
-          "$ref": "#/$defs/thermal_shutdown"
+        "thermal_regulation": {
+          "$ref": "#/$defs/thermal_regulation"
         },
         "cut_in_rpm": {
           "$ref": "#/$defs/cut_in_rpm"

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -436,7 +436,6 @@
         "rated_rpm",
         "cut_in_rpm",
         "rotor_diameter",
-        "rotor_tilt",
         "model_description",
         "available_hub_heights",
         "drive_type",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -8,4 +8,7 @@ def get_subschema(schema, section):
         if key not in [section]:
             schema["properties"].pop(key, None)
 
+    # Ensure that top level properties pass unnoticed if we only care about the subschema
+    schema["additionalProperties"] = True
+
     return schema

--- a/test/test_design_basis.py
+++ b/test/test_design_basis.py
@@ -1,9 +1,10 @@
 # Turn off pylint warnings unavoidable with pytest
 # pylint: disable=redefined-outer-name, line-too-long, redefined-builtin, missing-module-docstring
 
+import pytest
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
-import pytest
+
 from .helpers import get_subschema
 
 
@@ -19,7 +20,5 @@ def test_generic_11_3_design_basis_1(subschema, generic_117_3):
 
 
 def test_missing_design_basis(subschema):
-    """Validation should fail if there is no design basis section"""
-    with pytest.raises(ValidationError) as e:
-        validate(instance={}, schema=subschema)
-    assert "'design_bases' is a required property" in str(e)
+    """Validation should pass if there is no design basis section"""
+    validate(instance={}, schema=subschema)

--- a/test/test_turbine.py
+++ b/test/test_turbine.py
@@ -33,8 +33,6 @@ def test_missing_turbine(subschema):
         "model_name",
         "manufacturer_name",
         "rated_power",
-        "rated_rpm",
-        "cut_in_rpm",
         "rotor_diameter",
         "model_description",
         "available_hub_heights",
@@ -89,9 +87,7 @@ def test_name_length_limits(subschema, generic_turbine, property):
     assert "is too long" in str(e)
 
 
-@pytest.mark.parametrize(
-    "available_hub_heights", [{"max": 168, "min": 84}, [100, 110, 112.3]]
-)
+@pytest.mark.parametrize("available_hub_heights", [{"max": 168, "min": 84}, [100, 110, 112.3]])
 def test_available_hub_heights(subschema, generic_turbine, available_hub_heights):
     """Hub heights should be definable as a continuous range of values or as a list of numbers"""
     generic_turbine["turbine"]["available_hub_heights"] = available_hub_heights
@@ -109,13 +105,9 @@ def test_available_hub_heights(subschema, generic_turbine, available_hub_heights
         ),  # 41 characters
     ],
 )
-def test_invalid_manufacturer_display_names(
-    subschema, generic_turbine, manufacturer_display_name
-):
+def test_invalid_manufacturer_display_names(subschema, generic_turbine, manufacturer_display_name):
     """Ensure manufacturer_display_name is validated as a string of maximum length"""
-    generic_turbine["turbine"]["manufacturer_display_name"] = manufacturer_display_name[
-        0
-    ]
+    generic_turbine["turbine"]["manufacturer_display_name"] = manufacturer_display_name[0]
     with pytest.raises(ValidationError) as e:
         validate(instance=generic_turbine, schema=subschema)
     assert manufacturer_display_name[1] in str(e)


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#98](https://github.com/octue/power-curve-schema/pull/98))

### New features
- Rename thermal_shutdown to thermal_regulation to close #80
- Allow additional data and documentation
- Add design_lifetime definition into design_bases section

### Enhancements
- Make design_basis section optional
- The rotor_tilt prop is no longer required
- Rated and cut in rpm properties are no longer required
- Constrain the ability to pass with additional properties
- Add legend to deratings to allow additiona context data
- Make examples consistent
- Relax constraint on additional data section
- Remove attribute deprecated in the 2029 jsonschema draft

### Fixes
- Consistent and more flexible legend schema for the derating curves

### Testing
- Fix test case extraction of subschema

<!--- END AUTOGENERATED NOTES --->