### PR TITLE
[8] Allow temperature-only derating and update available hub heights description

### DIFF
--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -177,7 +177,7 @@
           "minItems": 1,
           "items": {
             "type": "object",
-            "oneOf": [
+            "anyOf": [
               {
                 "title": "Altitude and temperature based derating",
                 "required": ["altitude", "power_limit", "temperature"],


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#105](https://github.com/octue/power-curve-schema/pull/105))

### New features
- Allow temperature-only derating for thermal regulation

### Fixes
- Meet linter requirements by relaxing deratings from  to

### Other
- Clarify available hub heights override description
- Update reason for overriding available hub heights
- Update thermal regulation properties to include units in description

### Uncategorised!
- Merge branch 'main' into meeting-2-sep

<!--- END AUTOGENERATED NOTES --->