### PR TITLE
Make available_hub_heights optional and explain why

### DIFF
--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -63,7 +63,7 @@
     },
     "available_hub_heights": {
       "title": "Available hub heights",
-      "description": "Specify either a discrete list or a continuous range of available hub heights [m]. This value may be overriden to a more restricted subset on a per-mode basis, to allow for specific limitations (such as avoidance of tower resonance).",
+      "description": "Specify either a discrete list or a continuous range of available hub heights [m]. This value may be overriden to a more restricted subset on a per-mode basis, to allow for specific limitations (such as avoidance of tower resonance). In the early stages of turbine or platform development, this range may not be known so may be omitted.",
       "anyOf": [
         {
           "title": "Specify a range of available hub heights [m]",
@@ -471,7 +471,6 @@
         "rated_power",
         "rotor_diameter",
         "model_description",
-        "available_hub_heights",
         "drive_type",
         "regulation_type",
         "grid_frequencies",

--- a/test/test_turbine.py
+++ b/test/test_turbine.py
@@ -35,7 +35,6 @@ def test_missing_turbine(subschema):
         "rated_power",
         "rotor_diameter",
         "model_description",
-        "available_hub_heights",
         "drive_type",
         "regulation_type",
         "number_of_blades",


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#111](https://github.com/octue/power-curve-schema/pull/111))

### Enhancements
- Make available_hub_heights optional and explain why

<!--- END AUTOGENERATED NOTES --->