### PR TITLE
Clarify and unify `design_lifetime` into single field

### DIFF
--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -718,23 +718,16 @@
                     "description": "The design vertical inclination (inflow) angle [degrees]",
                     "type": "number",
                     "examples": [8, 0, -8]
-                  },
-                  "design_lifetime": {
-                    "$comment": "Schema team - check if this also needs to be given for T, CC classes as well as S class",
-                    "title": "Design lifetime",
-                    "description": "Designed lifetime of the turbine in years, typically 20. Note that some design classes require particular minimum lifetimes.",
-                    "type": "number",
-                    "exclusiveMinimum": 0,
-                    "examples": [20, 30]
                   }
                 }
               }
             ]
           },
           "design_lifetime": {
-            "title": "Design Lifetime",
-            "description": "The design lifetime of the turbine [years]",
+            "title": "Design lifetime",
+            "description": "The design lifetime of the turbine [years]. Note that some design classes require particular minimum lifetimes.",
             "type": "number",
+            "exclusiveMinimum": 0,
             "examples": [25, 30]
           },
           "turbulence": {


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#118](https://github.com/octue/power-curve-schema/pull/118))

### Enhancements
- Clarify and unify design_lifetime into single field

<!--- END AUTOGENERATED NOTES --->