### PR TITLE
De-requirements: Make things that can be empty anyway optional

### DIFF
--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -580,10 +580,7 @@
         "type": "object",
         "required": [
           "label",
-          "name",
-          "design_class",
-          "turbulence",
-          "standard_climate"
+          "name"
         ],
         "additionalProperties": false,
         "properties": {
@@ -1066,8 +1063,7 @@
               "cuts",
               "parameters",
               "power",
-              "thrust_coefficient",
-              "overrides"
+              "thrust_coefficient"
             ],
             "additionalProperties": false,
             "properties": {

--- a/test/test_power_curves.py
+++ b/test/test_power_curves.py
@@ -90,7 +90,6 @@ def test_missing_mode_properties(subschema, one_dimensional_mode):
     """Validation should fail if there is no overrides section in a mode"""
 
     for required in [
-        "overrides",
         "cuts",
         "parameters",
         "power",


### PR DESCRIPTION
In some cases, fields containing complex objects can be empty for practical purposes. In those cases, it doesn't make sense to be requiring an empty data structure above them.

<!--- START AUTOGENERATED NOTES --->
<!--- END AUTOGENERATED NOTES --->
