### PR TITLE
Update the design_lifetime location in the s-class generic example

### DIFF
--- a/power-curve-schema/examples/generic-120-3.json
+++ b/power-curve-schema/examples/generic-120-3.json
@@ -125,9 +125,9 @@
         "reference_wind_speed": 37.5,
         "weibull_shape_factor": 2.4,
         "vertical_shear_exponent": 0.3,
-        "inclination_angle": 8,
-        "design_lifetime": 25
+        "inclination_angle": 8
       },
+      "design_lifetime": 25,
       "turbulence": {
         "category": "A"
       },


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#129](https://github.com/octue/power-curve-schema/pull/129))

### Fixes
- Update the design_lifetime location in hte s-class generic example

<!--- END AUTOGENERATED NOTES --->