### PR TITLE
Rename shear-coefficient parameter to vertical-shear-exponent

### DIFF
--- a/lenses/lenses.py
+++ b/lenses/lenses.py
@@ -18,10 +18,21 @@ def _add_power_reference_location(doc, value="low-voltage"):
     return doc
 
 
+def _change_shear_coefficient_to_vertical_shear_exponent(doc):
+    """Unify the shear-coefficient parameter to call it vertical-shear-exponent consistent with usage elsewhere"""
+
+    for mode in doc["power_curves"]["operating_modes"]:
+        for parameter in mode["parameters"]:
+            if parameter["label"] == "shear-coefficient":
+                parameter["label"] = "vertical-shear-exponent"
+
+    return doc
+
+
 def alpha_3_to_alpha_4(doc):
     """Convert documents compliant with alpha-3 to documents compliant with alpha-4"""
 
-    lenses = [_add_power_reference_location]
+    lenses = [_add_power_reference_location, _change_shear_coefficient_to_vertical_shear_exponent]
     for lens in lenses:
         doc = lens(doc)
     return doc

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -1157,7 +1157,7 @@
                         "turbulence-intensity",
                         "turbulence-lengthscale",
                         "monin-obukhov-stability",
-                        "shear-coefficient",
+                        "vertical-shear-exponent",
                         "wind-direction"
                       ],
                       "title": "Parameter label",
@@ -1275,15 +1275,15 @@
                       "if": {
                         "properties": {
                           "label": {
-                            "const": "shear-coefficient"
+                            "const": "vertical-shear-exponent"
                           }
                         }
                       },
                       "then": {
                         "properties": {
                           "values": {
-                            "title": "Shear Coefficient Values",
-                            "description": "Values of wind shear coefficient alpha [-] for which this power curve is tabulated"
+                            "title": "Vertical Shear Exponent Values",
+                            "description": "Values of vertical wind shear exponent alpha [-] for which this power curve is tabulated"
                           }
                         },
                         "required": ["values"]

--- a/test/test_lenses.py
+++ b/test/test_lenses.py
@@ -7,7 +7,7 @@ import os
 
 import pytest
 
-from lenses.lenses import _add_power_reference_location
+from lenses.lenses import _add_power_reference_location, _change_shear_coefficient_to_vertical_shear_exponent
 
 from .conftest import ROOT_DIR
 
@@ -55,3 +55,12 @@ def test_add_power_reference_location_fails_with_invalid_input(generic_120_3_alp
 
     with pytest.raises(ValueError):
         _add_power_reference_location(generic_120_3_alpha_3)
+
+
+def test_rename_shear_coefficient(generic_120_3_alpha_3):
+    """Should rename a parameter label"""
+    # We don't have a test fixture with this so add it for the purpose. This is physically meaningless but tests the code.
+    generic_120_3_alpha_3["power_curves"]["operating_modes"][0]["parameters"][1]["label"] = "shear-coefficient"
+
+    transformed = _change_shear_coefficient_to_vertical_shear_exponent(generic_120_3_alpha_3)
+    assert transformed["power_curves"]["operating_modes"][0]["parameters"][1]["label"] == "vertical-shear-exponent"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#131](https://github.com/octue/power-curve-schema/pull/131))

### Enhancements
- Rename shear-coefficient parameter to vertical-shear-exponent

<!--- END AUTOGENERATED NOTES --->