### PR TITLE
Clarify intent by renaming the available_hub_height overrides

### DIFF
--- a/lenses/lenses.py
+++ b/lenses/lenses.py
@@ -29,10 +29,25 @@ def _change_shear_coefficient_to_vertical_shear_exponent(doc):
     return doc
 
 
+def _move_available_hub_heights_to_restricted(doc):
+    """Move overrides.available_hub_heights to mode-level restricted_to_hub_heights"""
+
+    for mode in doc["power_curves"]["operating_modes"]:
+        overrides = mode.get("overrides", {})
+        if "available_hub_heights" in overrides:
+            mode["restricted_to_hub_heights"] = overrides.pop("available_hub_heights")
+
+    return doc
+
+
 def alpha_3_to_alpha_4(doc):
     """Convert documents compliant with alpha-3 to documents compliant with alpha-4"""
 
-    lenses = [_add_power_reference_location, _change_shear_coefficient_to_vertical_shear_exponent]
+    lenses = [
+        _add_power_reference_location,
+        _change_shear_coefficient_to_vertical_shear_exponent,
+        _move_available_hub_heights_to_restricted,
+    ]
     for lens in lenses:
         doc = lens(doc)
     return doc

--- a/power-curve-schema/examples/generic-274-20.json
+++ b/power-curve-schema/examples/generic-274-20.json
@@ -822,9 +822,8 @@
             0.029, 0.027, 0.025, 0.024, 0.023, 0.021, 0.02, 0.019, 0.018
           ]
         ],
-        "overrides": {
-          "available_hub_heights": [140, 150]
-        }
+        "restricted_to_hub_heights": [140, 150],
+        "overrides": {}
       }
     ]
   }

--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -63,7 +63,7 @@
     },
     "available_hub_heights": {
       "title": "Available hub heights",
-      "description": "Specify either a discrete list or a continuous range of available hub heights [m]. This value may be overriden to a more restricted subset on a per-mode basis, to allow for specific limitations (such as avoidance of tower resonance). In the early stages of turbine or platform development, this range may not be known so may be omitted.",
+      "description": "Specify either a discrete list or a continuous range of available hub heights [m]. In the early stages of turbine or platform development, this range may not be known so may be omitted.",
       "anyOf": [
         {
           "title": "Specify a range of available hub heights [m]",
@@ -99,6 +99,11 @@
         },
         [120, 180]
       ]
+    },
+    "restricted_to_hub_heights": {
+      "$ref": "#/$defs/available_hub_heights",
+      "title": "Restricted to hub heights",
+      "description": "Selection of this mode is restricted to turbines with hub heights in the given ranges (allowing for specific limitations such as avoidance of tower resonance). Ranges should be specified as either a discrete list or a continuous range of hub heights [m], and should be a subset of turbine.available_hub_heights. If this property is omitted, selection of this mode is possible irrespective of hub height."      
     },
     "grid_frequencies": {
       "title": "Grid frequencies [Hz]",
@@ -1541,17 +1546,17 @@
                   }
                 ]
               },
+              "restricted_to_hub_heights": {
+                "$ref": "#/$defs/restricted_to_hub_heights"
+              },
               "overrides": {
                 "title": "Mode-Specific Overrides",
-                "description": "Override of certain data in the `turbine` section, where that data conflicts with requirements of a mode. For example, some operating modes may reduce rated power, or require a more restrictive range of hub heights for structural reasons",
+                "description": "Override of certain data in the `turbine` section, where that data conflicts with requirements of a mode. For example, some operating modes may reduce rated power.",
                 "type": "object",
                 "required": [],
                 "examples": [
                   {
                     "rated_power": 20e6
-                  },
-                  {
-                    "available_hub_heights": [100, 120]
                   },
                   {
                     "cut_in_rpm": 2.1
@@ -1570,9 +1575,6 @@
                   },
                   "rated_rpm": {
                     "$ref": "#/$defs/rated_rpm"
-                  },
-                  "available_hub_heights": {
-                    "$ref": "#/$defs/available_hub_heights"
                   }
                 }
               }

--- a/test/test_power_curves.py
+++ b/test/test_power_curves.py
@@ -167,12 +167,6 @@ def test_invalid_overrides(subschema, one_dimensional_mode):
         ),
         (
             {
-                "available_hub_heights": "not an array or hub heights dict",
-            },
-            "is not valid under any of the given schemas",
-        ),
-        (
-            {
                 "rated_rpm": "not an rpm value",
             },
             "is not of type 'number'",
@@ -200,6 +194,46 @@ def test_invalid_overrides(subschema, one_dimensional_mode):
             )
 
         assert reason in str(e)
+
+
+@pytest.mark.parametrize(
+    "restricted_to_hub_heights",
+    [
+        {"min": 100, "max": 140},
+        {"min": 100},
+        [100, 120, 140],
+    ],
+)
+def test_restricted_to_hub_heights(subschema, one_dimensional_mode, restricted_to_hub_heights):
+    """Restricted hub heights should be definable as a continuous range or as a list of numbers"""
+    one_dimensional_mode["restricted_to_hub_heights"] = restricted_to_hub_heights
+    validate(
+        instance={
+            "power_curves": {
+                "default_operating_mode_label": "one_dimensional",
+                "operating_modes": [one_dimensional_mode],
+            }
+        },
+        schema=subschema,
+    )
+
+
+def test_invalid_restricted_to_hub_heights(subschema, one_dimensional_mode):
+    """Validation should fail if restricted_to_hub_heights is invalid"""
+    one_dimensional_mode["restricted_to_hub_heights"] = "not an array or hub heights dict"
+
+    with pytest.raises(ValidationError) as e:
+        validate(
+            instance={
+                "power_curves": {
+                    "default_operating_mode_label": "one_dimensional",
+                    "operating_modes": [one_dimensional_mode],
+                }
+            },
+            schema=subschema,
+        )
+
+    assert "is not valid under any of the given schemas" in str(e)
 
 
 def test_acoustic_emissions(subschema, one_dimensional_mode):


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#133](https://github.com/octue/power-curve-schema/pull/133))

### Enhancements
- Clarify intent by renaming the available_hub_height overrides

<!--- END AUTOGENERATED NOTES --->