### PR TITLE
Align docs to standard and vice versa

### DIFF
--- a/power-curve-schema/schema.json
+++ b/power-curve-schema/schema.json
@@ -822,7 +822,7 @@
               {
                 "title": "Special turbulence category",
                 "type": "object",
-                "description": "Specify reference turbulence intensity",
+                "description": "Specify reference turbulence intensity consistent with IEC61400-1 Eds. 3 and 4",
                 "required": ["category", "reference_turbulence_intensity"],
                 "additionalProperties": false,
                 "properties": {
@@ -845,7 +845,7 @@
                 "title": "Characteristic turbulence intensity and slope",
                 "type": "object",
                 "description": "Specify characteristic turbulence intensity and slope consistent with IEC61400-1 Ed2",
-                "required": ["category", "characteristic_turbulence_intensity"],
+                "required": ["category", "characteristic_turbulence_intensity", "slope"],
                 "additionalProperties": false,
                 "properties": {
                   "category": {
@@ -865,7 +865,7 @@
                   "slope": {
                     "type": "number",
                     "title": "Slope (a)",
-                    "description": "Specify the slope parameter (a). No slope parameter is used for 61400-1 editions 3 or 4.",
+                    "description": "Specify the slope parameter (a)",
                     "minimum": 0,
                     "examples": [2, 3]
                   }


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#136](https://github.com/octue/power-curve-schema/pull/136))

### Fixes
- Clarify requiredness and purpose of slope parameter under eds 3 and 4

### Other
- Fix typos in descriptions
- Clarify field name

<!--- END AUTOGENERATED NOTES --->